### PR TITLE
[Bugfix 1.0] Quickfix getOperatingSystem, used to determine instructions in CreateMtlsView

### DIFF
--- a/src/hook/helpers/getOperatingSystem.ts
+++ b/src/hook/helpers/getOperatingSystem.ts
@@ -7,8 +7,6 @@ export function getOperatingSystem() {
     os = "MacOS";
   } else if (/Win/i.test(platform)) {
     os = "Windows";
-  } else if (/Linux/i.test(platform)) {
-    os = "Linux";
   } else if (/Android/i.test(userAgent)) {
     os = "Android";
   } else if (/iPhone|iPad|iPod/i.test(userAgent)) {

--- a/src/views/servicetak/quickstartguide/wintak/TakQuickstartWin2.tsx
+++ b/src/views/servicetak/quickstartguide/wintak/TakQuickstartWin2.tsx
@@ -51,7 +51,7 @@ export function TakQuickstartWin2() {
                   <strong>Puolustusvoimien osoittamasta paikasta</strong>.
                   <br />
                   <br />
-                  <strong>Lataa</strong> strong painamalla kuvaketta alta:
+                  <strong>Lataa</strong> painamalla kuvaketta alta:
                 </>
               }
               image2Src={windownload}


### PR DESCRIPTION
# What
Rather temporarily fix a problem that appears to occur with various Android devices, with how /assets/helpers/getOperatingSystem is made to work. The implementation thinks some android flavour devices are "linux." 

Also a little typo in QuickstartGuide wintak.

# Why
As CreateMtlsView uses this helper to determine which instructions to show the user, this is rather irritating bug.

# Changes 
Remove the option of determining "a Linux" altogether and make the determination to fallback to Android if that is the case.

# What next
Should make this logic not this fragile in the future & probably include CreateMtlsView a feature for the user to change the instruction type themselves.